### PR TITLE
feat(email): added Metadata to model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
 language: go
 go:
-  - 1.17.x
-  - tip
+  - 1.19.x

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ emailReq := &postmark.Email{
   },
   Tag:        "onboarding",
   TrackOpens: true,
+  Metadata: map[string]string{
+    "client-id": "123456",
+    "client-ip": "127.0.0.1",
+  },
 }
 
 email, response, err := client.Email.Send(emailReq)
@@ -63,6 +67,10 @@ emailReq := &postmark.Email{
   TextBody:   "Hello dear Postmark user",
   Tag:        "onboarding",
   TrackOpens: true,
+  Metadata: map[string]string{
+    "client-id": "123456",
+    "client-ip": "127.0.0.1",
+  },
 }
 
 email, response, err := client.Email.Send(emailReq)

--- a/email.go
+++ b/email.go
@@ -32,6 +32,7 @@ type Email struct {
 	Attachments   []EmailAttachment      `json:",omitempty"`
 	TrackOpens    bool                   `json:",omitempty"`
 	MessageStream string                 `json:",omitempty"`
+	Metadata      map[string]string      `json:",omitempty"`
 }
 
 // EmailHeader represents the values for an email header.

--- a/examples/send-email/main.go
+++ b/examples/send-email/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	postmark "github.com/mattevans/postmark-go"
+	"github.com/mattevans/postmark-go"
 )
 
 func main() {
@@ -23,6 +23,10 @@ func main() {
 		TextBody:   "Hello dear Postmark user",
 		Tag:        "onboarding",
 		TrackOpens: true,
+		Metadata: map[string]string{
+			"client-id": "123456",
+			"client-ip": "127.0.0.1",
+		},
 	}
 
 	// Send it!

--- a/postmark.go
+++ b/postmark.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 )
 
 const (
-	packageVersion = "0.1.5"
+	packageVersion = "0.1.6"
 	backendURL     = "https://api.postmarkapp.com"
 	userAgent      = "postmark-go/" + packageVersion
 )
@@ -152,7 +151,7 @@ func CheckResponse(r *http.Response) error {
 
 	errorResponse := &ErrorResponse{Response: r}
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && len(data) > 0 {
 		err := json.Unmarshal(data, errorResponse)
 		if err != nil {


### PR DESCRIPTION
Adds `Metadata` to the email model to support custom metadata key/value pairs.

https://postmarkapp.com/developer/api/email-api

Usage:

```go
emailReq := &postmark.Email{
  From:       "mail@company.com",
  To:         "jack@sparrow.com",
  TemplateID: 123456,
  TemplateModel: map[string]interface{}{
    "name": "Jack",
    "action_url": "http://click.company.com/welcome",
  },
  Tag:        "onboarding",
  TrackOpens: true,
  Metadata: map[string]string{
    "client-id": "123456",
    "client-ip": "127.0.0.1",
  },
}
```

