### PR TITLE
feat(client): new client signature now takes opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ postmark-go is a [Go](http://golang.org) client library for accessing the Postma
 This is an unofficial library that is not affiliated with [Postmark](http://postmarkapp.com). Official libraries are available
 [here](http://developer.postmarkapp.com/developer-official-libs.html).
 
+v1.0 Breaking Changes
+---------------------
+The signature of `NewClient` has changed. It now accepts options, one of which can be a custom HTTP client. Please pin to an older version if required.
+
 Installation
 -----------------
 
@@ -20,13 +24,14 @@ Setup
 You'll need to pass an `SERVER_API_TOKEN` when initializing the client. This token can be
 found under the 'Credentials' tab of your Postmark server. More info [here](http://developer.postmarkapp.com/developer-api-overview.html#authentication).
 
-Authentication
--------------
+Client + Authentication
+-----------------------
 ```go
-auth := &http.Client{
-  Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
-}
-client := postmark.NewClient(auth)
+client := postmark.NewClient(
+    postmark.WithClient(&http.Client{
+        Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
+    }),
+)
 ```
 
 Example usage (with Template)

--- a/examples/batch-emails/main.go
+++ b/examples/batch-emails/main.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"net/http"
 
-	postmark "github.com/mattevans/postmark-go"
+	"github.com/mattevans/postmark-go"
 )
 
 func main() {
-	// Authenticate.
-	auth := &http.Client{
-		Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
-	}
-	client := postmark.NewClient(auth)
+	// Init client with round tripper adding auth fields.
+	client := postmark.NewClient(
+		postmark.WithClient(&http.Client{
+			Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
+		}),
+	)
 
 	// Slice of recievers
 	receivers := []string{

--- a/examples/bounce/main.go
+++ b/examples/bounce/main.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"net/http"
 
-	postmark "github.com/mattevans/postmark-go"
+	"github.com/mattevans/postmark-go"
 )
 
 func main() {
-	// Authenticate.
-	auth := &http.Client{
-		Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
-	}
-	client := postmark.NewClient(auth)
+	// Init client with round tripper adding auth fields.
+	client := postmark.NewClient(
+		postmark.WithClient(&http.Client{
+			Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
+		}),
+	)
 
 	// Get delivery stats.
 	stats, response, err := client.Bounce.GetDeliveryStats()

--- a/examples/send-email-attachment/main.go
+++ b/examples/send-email-attachment/main.go
@@ -6,15 +6,16 @@ import (
 	"net/http"
 	"path/filepath"
 
-	postmark "github.com/mattevans/postmark-go"
+	"github.com/mattevans/postmark-go"
 )
 
 func main() {
-	// Authenticate.
-	auth := &http.Client{
-		Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
-	}
-	client := postmark.NewClient(auth)
+	// Init client with round tripper adding auth fields.
+	client := postmark.NewClient(
+		postmark.WithClient(&http.Client{
+			Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
+		}),
+	)
 
 	// Build the email.
 	emailReq := &postmark.Email{

--- a/examples/send-email/main.go
+++ b/examples/send-email/main.go
@@ -8,11 +8,12 @@ import (
 )
 
 func main() {
-	// Authenticate.
-	auth := &http.Client{
-		Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
-	}
-	client := postmark.NewClient(auth)
+	// Init client with round tripper adding auth fields.
+	client := postmark.NewClient(
+		postmark.WithClient(&http.Client{
+			Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
+		}),
+	)
 
 	// Build the email.
 	emailReq := &postmark.Email{

--- a/options.go
+++ b/options.go
@@ -1,0 +1,49 @@
+package postmark
+
+import "net/http"
+
+// Option to set an optional client value.
+type Option func(o *Options)
+
+// Options for our client.
+type Options struct {
+	Client     *http.Client
+	BackendURL string
+	UserAgent  string
+}
+
+// NewOptions returns a new Options with defaults and supplied overrides.
+func NewOptions(opts ...Option) *Options {
+	out := Options{
+		Client:     http.DefaultClient,
+		BackendURL: backendURL,
+		UserAgent:  userAgent,
+	}
+
+	for _, o := range opts {
+		o(&out)
+	}
+
+	return &out
+}
+
+// WithClient ...
+func WithClient(v *http.Client) Option {
+	return func(o *Options) {
+		o.Client = v
+	}
+}
+
+// WithBackendURL ...
+func WithBackendURL(v string) Option {
+	return func(o *Options) {
+		o.BackendURL = v
+	}
+}
+
+// WithUserAgent ...
+func WithUserAgent(v string) Option {
+	return func(o *Options) {
+		o.UserAgent = v
+	}
+}

--- a/options.go
+++ b/options.go
@@ -27,21 +27,21 @@ func NewOptions(opts ...Option) *Options {
 	return &out
 }
 
-// WithClient ...
+// WithClient allows you to set a custom http client.
 func WithClient(v *http.Client) Option {
 	return func(o *Options) {
 		o.Client = v
 	}
 }
 
-// WithBackendURL ...
+// WithBackendURL allows you to set a custom backend URL.
 func WithBackendURL(v string) Option {
 	return func(o *Options) {
 		o.BackendURL = v
 	}
 }
 
-// WithUserAgent ...
+// WithUserAgent allows you to set a custom user agent.
 func WithUserAgent(v string) Option {
 	return func(o *Options) {
 		o.UserAgent = v

--- a/postmark.go
+++ b/postmark.go
@@ -10,18 +10,17 @@ import (
 )
 
 const (
-	packageVersion = "0.1.6"
+	packageVersion = "1.0.0"
 	backendURL     = "https://api.postmarkapp.com"
 	userAgent      = "postmark-go/" + packageVersion
 )
 
 // Client holds a connection to the Postmark API.
 type Client struct {
-	client         *http.Client
-	Token          string
-	ConnectionType string
-	UserAgent      string
-	BackendURL     *url.URL
+	client     *http.Client
+	Token      string
+	UserAgent  string
+	BackendURL *url.URL
 
 	// Services used for communicating with the API.
 	Email    *EmailService
@@ -54,22 +53,21 @@ func (r *ErrorResponse) Error() string {
 
 // NewClient creates a new Client with the appropriate connection details and
 // services used for communicating with the API.
-func NewClient(httpClient *http.Client) *Client {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	baseURL, _ := url.Parse(backendURL)
-
-	c := &Client{
-		client:     httpClient,
-		BackendURL: baseURL,
-		UserAgent:  userAgent,
-	}
+func NewClient(opts ...Option) *Client {
+	var (
+		options    = NewOptions(opts...)
+		baseURL, _ = url.Parse(options.BackendURL)
+		c          = &Client{
+			client:     options.Client,
+			UserAgent:  options.UserAgent,
+			BackendURL: baseURL,
+		}
+	)
 
 	c.Email = &EmailService{client: c}
 	c.Bounce = &BounceService{client: c}
 	c.Template = &TemplateService{client: c}
+
 	return c
 }
 
@@ -80,7 +78,6 @@ func (c *Client) NewRequest(method, urlPath string, body interface{}) (*http.Req
 	if err != nil {
 		return nil, err
 	}
-
 	u := c.BackendURL.ResolveReference(rel)
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
The signature of `NewClient` has changed. It now accepts options, one of which can be a custom HTTP client. 

Client can now be initialised as follows...

```go
client := postmark.NewClient(
    postmark.WithClient(&http.Client{
        Transport: &postmark.AuthTransport{Token: "SERVER_API_TOKEN"},
    }),
)
```

This is a breaking change, and will be released as `v1.0`.
